### PR TITLE
No blocks adjacent to cloud issue#42

### DIFF
--- a/tempus_fugit_minecraft/model.py
+++ b/tempus_fugit_minecraft/model.py
@@ -399,3 +399,14 @@ class Model(object):
         """
         block_type = self.world.get(player_current_coords)
         return block_type in [LIGHT_CLOUD,DARK_CLOUD]
+    
+    #issue42
+    def is_it_cloud_texture(self, texture):
+        """!
+        @brief Check if the texture is of type cloud.
+        
+        @param texture The texture that was clicked by the mouse left-button.
+        
+        @return True if the texture belong to clouds' textures, False otherwise.
+        """
+        return texture in [LIGHT_CLOUD,DARK_CLOUD]

--- a/tempus_fugit_minecraft/model.py
+++ b/tempus_fugit_minecraft/model.py
@@ -134,15 +134,12 @@ class Model(object):
         return False
 
     def add_block(self, position: tuple, texture: list, immediate=True) -> None:
-        """Add a block with the given `texture` and `position` to the world.
+        """!
+        @brief Add a block with the given `texture` and `position` to the world.
 
-        Parameters
-        ----------
-        position : tuple of len 3
-            The (x, y, z) position of the block to add.
-        texture : list of len 3
-            The coordinates of the texture squares. Use `tex_coords()` to
-            generate.
+        @param position The (x, y, z) position of the block to add.
+        @param texture The coordinates of the texture squares. Use `tex_coords()`
+            to generate.
         immediate : bool
             Whether to draw the block immediately.
         """
@@ -348,21 +345,16 @@ class Model(object):
         while self.queue:
             self._dequeue()
 
+    #issue20; #issue28
     @staticmethod
     def generate_clouds_positions(world_size: int, num_of_clouds=250) -> list:
-        """Generate the position of the clouds on the sky.
-
-        Parameters
-        ----------
-        world_size : int
-            1/2 size of the world.
-        num_of_clouds : int
-            Default clouds to be generated = 250
-
-        Returns
-        -------
-        clouds : list of lists
-            Each inner list represents a set of cloud blocks.
+        """!
+        @brief Generate sky cloud positions.
+        
+        @param world_size Half the world's size.
+        @param num_of_clouds Number of clouds (default is 250).
+        
+        @return clouds list of lists representing cloud blocks coordinates.
         """
         game_margin = world_size
         clouds = list()
@@ -381,14 +373,14 @@ class Model(object):
             clouds.append(single_cloud)
         return clouds
 
-
+    #issue20; #issue28
     def place_cloud_blocks(self, clouds):
-        """
-        represent each cloud block's coordinates with a cloud block in the sky.
+        """!
+        @breif represent cloud block's coordinates in the sky.
 
-        Input: clouds: list of lists; each inner list is a set of cloud block's coordinates.
+        @param clouds list of lists; each inner list contains cloud block's coordinates.
 
-        output: draw a cloud block with its corresponding coordinates.
+        @return None, but draw a cloud block at its corresponding coordinates.
         """
         cloud_types = [LIGHT_CLOUD,DARK_CLOUD]
         for cloud in clouds:

--- a/tempus_fugit_minecraft/model.py
+++ b/tempus_fugit_minecraft/model.py
@@ -388,18 +388,14 @@ class Model(object):
             for x,y,z in cloud:
                 self.add_block((x,y,z) , cloud_color , immediate=False)
 
+    #issue57
     def can_pass_through_block(self, player_current_coords):
-        """
-        check if the block at the given palyer_current_coords is a cloud block
+        """!
+        @brief Check if the block at the given palyer_current_coords is a cloud block.
         
-        Input
-        -----
-            player_current_coords: current (x,y,z) corrdinates for the player
+        @param player_current_coords Current (x,y,z) corrdinates for the player.
         
-        Output
-        ------
-            True: if the coords corresponding to a cloud block.
-            False: otherwise.
+        @return True if the coordinates correspond to a cloud block, False otherwise.
         """
         block_type = self.world.get(player_current_coords)
         return block_type in [LIGHT_CLOUD,DARK_CLOUD]

--- a/tempus_fugit_minecraft/window.py
+++ b/tempus_fugit_minecraft/window.py
@@ -227,8 +227,11 @@ class Window(pyglet.window.Window):
             block, previous = self.model.hit_test(self.player.position, vector)
             if (button == mouse.RIGHT) or ((button == mouse.LEFT) and (modifiers & key.MOD_CTRL)):
                 # ON OSX, control + left click = right click.
-                if previous:
-                    self.model.add_block(previous, self.player.block)
+                block_texture = self.model.world[block]
+                if previous and block:
+                    if not self.is_it_cloud_texture(block_texture):
+                        self.model.add_block(previous, self.player.block)
+                        
             elif button == pyglet.window.mouse.LEFT and block:
                 texture = self.model.world[block]
                 if texture != STONE:
@@ -509,3 +512,19 @@ class Window(pyglet.window.Window):
         """
         block_type = self.model.world.get(player_current_coords)
         return block_type in [LIGHT_CLOUD,DARK_CLOUD]
+    
+    def is_it_cloud_texture(self, texture):
+        """
+        check if the texture is of type cloud
+        
+        Input
+        -----
+            texture: The texture that was clicked by the mouse left-button.
+        
+        Output
+        ------
+            True: if the texture belong to clouds' textures.
+            False: otherwise.
+        """
+        print(f"is_it_cloud_texture? {texture in [LIGHT_CLOUD,DARK_CLOUD]}")
+        return texture in [LIGHT_CLOUD,DARK_CLOUD]

--- a/tempus_fugit_minecraft/window.py
+++ b/tempus_fugit_minecraft/window.py
@@ -187,7 +187,7 @@ class Window(pyglet.window.Window):
                     player_currnet_coords[1] -= dy
                     player_currnet_coords[i] += face[i]
                     block_type = self.model.world.get(tuple(player_currnet_coords))
-                    if block_type is None or self.is_it_cloud_coordinates(player_current_coords=tuple(player_currnet_coords)):
+                    if block_type is None or self.model.can_pass_through_block(player_current_coords=tuple(player_currnet_coords)):
                         continue
                     p[i] -= (d - pad) * face[i]
                     if face == (0, -1, 0) or face == (0, 1, 0):
@@ -497,19 +497,6 @@ class Window(pyglet.window.Window):
         """Draw the crosshairs in the center of the screen."""
         glColor3d(0, 0, 0)
         self.reticle.draw(GL_LINES)
-    
-    
-    #issue57
-    def is_it_cloud_coordinates(self, player_current_coords):
-        """!
-        @brief Check if the block at the given palyer_current_coords is a cloud block.
-        
-        @param player_current_coords Current (x,y,z) corrdinates for the player.
-        
-        @return True if the coordinates correspond to a cloud block, False otherwise.
-        """
-        block_type = self.model.world.get(player_current_coords)
-        return block_type in [LIGHT_CLOUD,DARK_CLOUD]
     
     #issue42
     def is_it_cloud_texture(self, texture):

--- a/tempus_fugit_minecraft/window.py
+++ b/tempus_fugit_minecraft/window.py
@@ -190,7 +190,7 @@ class Window(pyglet.window.Window):
                     player_currnet_coords[1] -= dy
                     player_currnet_coords[i] += face[i]
                     block_type = self.model.world.get(tuple(player_currnet_coords))
-                    if block_type is None or self.model.can_pass_through_block(player_current_coords=tuple(player_currnet_coords)):
+                    if block_type is None or self.is_it_cloud_coordinates(player_current_coords=tuple(player_currnet_coords)):
                         continue
                     p[i] -= (d - pad) * face[i]
                     if face == (0, -1, 0) or face == (0, 1, 0):
@@ -492,3 +492,20 @@ class Window(pyglet.window.Window):
         """Draw the crosshairs in the center of the screen."""
         glColor3d(0, 0, 0)
         self.reticle.draw(GL_LINES)
+    
+    
+    def is_it_cloud_coordinates(self, player_current_coords):
+        """
+        check if the block at the given palyer_current_coords is a cloud block
+        
+        Input
+        -----
+            player_current_coords: current (x,y,z) corrdinates for the player
+        
+        Output
+        ------
+            True: if the coords corresponding to a cloud block.
+            False: otherwise.
+        """
+        block_type = self.model.world.get(player_current_coords)
+        return block_type in [LIGHT_CLOUD,DARK_CLOUD]

--- a/tempus_fugit_minecraft/window.py
+++ b/tempus_fugit_minecraft/window.py
@@ -231,7 +231,7 @@ class Window(pyglet.window.Window):
                 # ON OSX, control + left click = right click.
                 if previous and block:
                     block_texture = self.model.world[block]
-                    if not self.is_it_cloud_texture(block_texture):
+                    if not self.model.is_it_cloud_texture(block_texture):
                         self.model.add_block(previous, self.player.block)
                         
             elif button == pyglet.window.mouse.LEFT and block:
@@ -497,14 +497,3 @@ class Window(pyglet.window.Window):
         """Draw the crosshairs in the center of the screen."""
         glColor3d(0, 0, 0)
         self.reticle.draw(GL_LINES)
-    
-    #issue42
-    def is_it_cloud_texture(self, texture):
-        """!
-        @brief Check if the texture is of type cloud.
-        
-        @param texture The texture that was clicked by the mouse left-button.
-        
-        @return True if the texture belong to clouds' textures, False otherwise.
-        """
-        return texture in [LIGHT_CLOUD,DARK_CLOUD]

--- a/tempus_fugit_minecraft/window.py
+++ b/tempus_fugit_minecraft/window.py
@@ -227,8 +227,8 @@ class Window(pyglet.window.Window):
             block, previous = self.model.hit_test(self.player.position, vector)
             if (button == mouse.RIGHT) or ((button == mouse.LEFT) and (modifiers & key.MOD_CTRL)):
                 # ON OSX, control + left click = right click.
-                block_texture = self.model.world[block]
                 if previous and block:
+                    block_texture = self.model.world[block]
                     if not self.is_it_cloud_texture(block_texture):
                         self.model.add_block(previous, self.player.block)
                         
@@ -526,5 +526,4 @@ class Window(pyglet.window.Window):
             True: if the texture belong to clouds' textures.
             False: otherwise.
         """
-        print(f"is_it_cloud_texture? {texture in [LIGHT_CLOUD,DARK_CLOUD]}")
         return texture in [LIGHT_CLOUD,DARK_CLOUD]

--- a/tempus_fugit_minecraft/window.py
+++ b/tempus_fugit_minecraft/window.py
@@ -154,21 +154,18 @@ class Window(pyglet.window.Window):
         x, y, z = self.collide((x + dx, y + dy, z + dz), self.player.PLAYER_HEIGHT)
         self.player.position = (x, y, z)
 
+    #issue57
     def collide(self, position: tuple, height: int) -> tuple:
-        """Checks to see if the player at the given `position` and `height`
-        is colliding with any blocks in the world.
+        """!
+        @brief Checks to see if the player at the given `position` and `height`
+            is colliding with any blocks in the world.
+        
+        @details If position for cloud texture, pass through clouds.
 
-        Parameters
-        ----------
-        position : tuple of len 3
-            The (x, y, z) position to check for collisions at.
-        height : int or float
-            The height of the player.
+        @param position The (x, y, z) position to check for collisions at.
+        @param height The height of the player.
 
-        Returns
-        -------
-        position : tuple of len 3
-            The new position of the player taking into account collisions.
+        @return position The new position of the player taking into account collisions.
         """
         # How much overlap with a dimension of a surrounding block you need to
         # have to count as a collision. If 0, touching terrain at all counts as
@@ -200,22 +197,27 @@ class Window(pyglet.window.Window):
                     break
         return tuple(p)
     
-
+    
+    #issue42
     def on_mouse_press(self, x: int, y: int, button: int, modifiers: int) -> None:
-        """Called when a mouse button is pressed. See pyglet docs for button
-        and modifier mappings.
+        """!
+        @brief Called when a mouse button is pressed. See pyglet docs for 
+            button and modifier mappings.
+        
+        @details If right-click on non-clouds texture, add_block() is called. 
+            Otherwise, the method is not called.
+        
+        @details If left-click on non-brick texture, remove_block() is called. 
+            Otherwise, the method is not called.
 
-        Parameters
-        ----------
-        x, y : int
-            The coordinates of the mouse click. Always center of the screen if
-            the mouse is captured.
-        button : int
-            Number representing mouse button that was clicked. 1 = left button,
-            4 = right button.
-        modifiers : int
-            Number representing any modifying keys that were pressed when the
-            mouse button was clicked.
+        @param x, y The coordinates of the mouse click. Always center of 
+            the screen if the mouse is captured.
+        @param button Number representing mouse button that was clicked. 
+            1 = left button, 4 = right button.
+        @param modifiers Number representing any modifying keys that 
+            were pressed when the mouse button was clicked.
+        
+        @return None
         """
         if self.paused:
             if self.within_label(x, y, self.resume_label):
@@ -497,33 +499,25 @@ class Window(pyglet.window.Window):
         self.reticle.draw(GL_LINES)
     
     
+    #issue57
     def is_it_cloud_coordinates(self, player_current_coords):
-        """
-        check if the block at the given palyer_current_coords is a cloud block
+        """!
+        @brief Check if the block at the given palyer_current_coords is a cloud block.
         
-        Input
-        -----
-            player_current_coords: current (x,y,z) corrdinates for the player
+        @param player_current_coords Current (x,y,z) corrdinates for the player.
         
-        Output
-        ------
-            True: if the coords corresponding to a cloud block.
-            False: otherwise.
+        @return True if the coordinates correspond to a cloud block, False otherwise.
         """
         block_type = self.model.world.get(player_current_coords)
         return block_type in [LIGHT_CLOUD,DARK_CLOUD]
     
+    #issue42
     def is_it_cloud_texture(self, texture):
-        """
-        check if the texture is of type cloud
+        """!
+        @brief Check if the texture is of type cloud.
         
-        Input
-        -----
-            texture: The texture that was clicked by the mouse left-button.
+        @param texture The texture that was clicked by the mouse left-button.
         
-        Output
-        ------
-            True: if the texture belong to clouds' textures.
-            False: otherwise.
+        @return True if the texture belong to clouds' textures, False otherwise.
         """
         return texture in [LIGHT_CLOUD,DARK_CLOUD]

--- a/tests/test_cloud.py
+++ b/tests/test_cloud.py
@@ -111,7 +111,7 @@ class TestClouds:
         assert model.can_pass_through_block((0,100,0)) == True
     
     #issue42
-    def test_mouse_press_on_clouds(self):
+    def test_click_mouse_to_add_block_to_clouds(self):
         model = Model()
         window = Window()
         window.model = model

--- a/tests/test_cloud.py
+++ b/tests/test_cloud.py
@@ -23,7 +23,7 @@ class TestClouds:
         window.paused = False
         window.exclusive = True
 
-
+    #issue20
     def test_light_clouds_created_dynamically(self, model):
         clouds = model.generate_clouds_positions(80, 100)
         for cloud in clouds:
@@ -31,6 +31,7 @@ class TestClouds:
                 model.add_block((x, c, z), LIGHT_CLOUD, immediate=True)
         assert LIGHT_CLOUD in model.world.values()
 
+    #issue20; #issue28
     def test_cloud_positions(self):
         model = Model()
         model.generate_clouds_positions(80, 100)
@@ -40,6 +41,7 @@ class TestClouds:
             assert -o <= block[0] <= o
             assert -o <= block[2] <= o
 
+    #issue20; #issue28
     def test_cloud_height(self):
         model = Model()
         model.generate_clouds_positions(80, 100)
@@ -47,12 +49,14 @@ class TestClouds:
         for cloud_coordinates in clouds:
             assert cloud_coordinates[1] >= 20
 
+    #issue20; #issue28
     def test_non_overlapping_clouds(self, model):
         model.generate_clouds_positions(80, 100)
         blocks_of_all_clouds = [coordinates for coordinates, block in model.world.items() if block in [LIGHT_CLOUD, DARK_CLOUD]]
         unique_clouds = set(blocks_of_all_clouds)
         assert len(blocks_of_all_clouds) == len(unique_clouds)
 
+    #issue28
     def test_dark_clouds_created_dynamically(self, model):
         clouds = model.generate_clouds_positions(80, 200)
         for cloud in clouds:
@@ -60,6 +64,7 @@ class TestClouds:
                 model.add_block((x, c, z), DARK_CLOUD, immediate=True)
         assert DARK_CLOUD in model.world.values()
 
+    #issue20; #issue28
     def test_draw_clouds_in_the_sky_and_count_blocks(self):
         model = Model()
         clouds = model.generate_clouds_positions(80, 150)
@@ -67,7 +72,8 @@ class TestClouds:
         cloud_blocks = [coordinates for coordinates, block in model.world.items() if block in [LIGHT_CLOUD, DARK_CLOUD]]
         assert len(cloud_blocks) >= sum(len(cloud) for cloud in clouds)
     
-    def test_pass_through_clouds(self, model):
+    #issue57
+    def test_pass_through_clouds(self, model, window):
         model.world[(0,50,0)] = LIGHT_CLOUD
         assert model.can_pass_through_block((0,50,0)) == True
         
@@ -75,7 +81,8 @@ class TestClouds:
         assert model.can_pass_through_block((0,52,0)) == True
     
     
-    def test_no_pass_through_objects_not_of_type_clouds(self, model):
+    #issue57
+    def test_no_pass_through_objects_not_of_type_clouds(self, model, window):
         model.world[(0,10,0)] = STONE
         assert model.can_pass_through_block((0,10,0)) == False
         
@@ -89,7 +96,8 @@ class TestClouds:
         assert model.can_pass_through_block((0,40,0)) == False
     
     
-    def test__try_pass_through_different_objects_added_at_same_position(self, model):
+    #issue57;
+    def test__try_pass_through_different_objects_added_at_same_position(self, model, window):
         block_type = model.world.get((0,100,0))
         assert block_type == None
         
@@ -102,8 +110,8 @@ class TestClouds:
         model.world[(0,100,0)] = DARK_CLOUD
         assert model.can_pass_through_block((0,100,0)) == True
     
-    
-    def test_no_textures_added_to_clouds(self):
+    #issue42
+    def test_mouse_press_on_clouds(self):
         model = Model()
         window = Window()
         window.model = model


### PR DESCRIPTION
Solve [Issue#42](https://github.com/WSUCEG-7140/Tempus_Fugit_Minecraft/issues/42)
* Add a new feature: Users cannot add blocks to the clouds.
  * When a user right-clicks the mouse while pointing at clouds, no action is taken.
* Functions used:
  * `on_mouse_press()`: A built-in function in pyglet that triggers an action when the user clicks the mouse.
  * When the user clicks the mouse, the function determines whether to call `add_block()` or not. If the block is of type cloud, `add_block()` is not called. Otherwise, `add_block()` is called.
  
  **Tests:**
* Include tests to verify that blocks cannot be added to clouds.

**Embedded Design Documentation:**
* Enhance the documentation of functions related to the clouds feature to ensure compatibility with `Doxygen`.
* Add the `issue#` number to each function related to the clouds feature, including `test_cloud.py`.