### PR TITLE
No cross boundaries issue#25

### DIFF
--- a/tempus_fugit_minecraft/model.py
+++ b/tempus_fugit_minecraft/model.py
@@ -486,6 +486,9 @@ class Model(object):
             if self.sector is None:
                 self.process_entire_queue()
             self.sector = sector
+        
+        self.player.check_player_within_world_boundaries()
+        
         moves = 8
         dt = min(dt, 0.2)
         for _ in xrange(moves):

--- a/tempus_fugit_minecraft/player.py
+++ b/tempus_fugit_minecraft/player.py
@@ -1,4 +1,4 @@
-from tempus_fugit_minecraft.utilities import BRICK, GRASS, SAND
+from tempus_fugit_minecraft.utilities import BRICK, GRASS, SAND, WHOLE_WORLD_SIZE, WORLD_SIZE
 import math
 
 class Player:
@@ -179,3 +179,38 @@ class Player:
         # collisions
         x, y, z = self.position
         self.position = collision_checker((x + dx, y + dy, z + dz), self.PLAYER_HEIGHT)
+    
+    #issue25
+    def check_player_within_world_boundaries(self):
+        """!
+        @brief Ensure that the player character remains within the 
+            confines of the defined game world.
+        
+        @param None
+        
+        @return None
+        """
+        x,y,z = self.position
+
+        x = self.keep_player_within_coordinates(x , boundary_size=WORLD_SIZE)
+        z = self.keep_player_within_coordinates(z , boundary_size=WORLD_SIZE)        
+        self.position = (x,y,z)
+
+    #issue25
+    def keep_player_within_coordinates(self, dimention, boundary_size):
+        """!
+        @brief check whether the dimention (usually x or z) is 
+            within the boundary size.
+        
+        @param dimention represent a player dimention (x,y, or z)
+        @param boundary_size represent the size of the world 
+            withing the walls.
+        
+        @return The dimension adjusted to be within the boundary size.
+        """
+        if dimention > boundary_size:
+            return boundary_size
+        elif dimention < -boundary_size:
+            return -boundary_size
+        else:
+            return dimention

--- a/tempus_fugit_minecraft/utilities.py
+++ b/tempus_fugit_minecraft/utilities.py
@@ -66,6 +66,8 @@ def tex_coords(top: tuple, bottom: tuple, side: tuple) -> list:
     result.extend(side * 4)
     return result
 
+WHOLE_WORLD_SIZE = 160
+WORLD_SIZE = int(WHOLE_WORLD_SIZE/2)
 TICKS_PER_SEC = 60
 GRASS = tex_coords((1, 0), (0, 1), (0, 0))
 SAND = tex_coords((1, 1), (1, 1), (1, 1))

--- a/tests/test_player.py
+++ b/tests/test_player.py
@@ -1,7 +1,7 @@
 import pytest
 import math
 from tempus_fugit_minecraft.player import Player
-from tempus_fugit_minecraft.utilities import BRICK, GRASS, SAND
+from tempus_fugit_minecraft.utilities import BRICK, GRASS, SAND, WHOLE_WORLD_SIZE, WORLD_SIZE
 
 @pytest.fixture(scope = "class")
 def player():
@@ -356,3 +356,51 @@ class TestPlayer:
                     assert p_x == m_x * player.current_speed()
                     assert p_y == m_y * player.current_speed()
                     assert p_z == m_z * player.current_speed()
+    
+    #issue25
+    def test_player_within_world_boundaries(self, player: Player):
+        player.position = (10,5,15)
+        player.check_player_within_world_boundaries()
+        assert player.position == (10,5,15)
+
+    # #issue25
+    def test_check_player_at_boundaries(self, player: Player):
+        player.position = (WORLD_SIZE , 20, WORLD_SIZE)
+        player.check_player_within_world_boundaries()
+        assert player.position == (WORLD_SIZE , 20, WORLD_SIZE)
+
+    #issue25
+    def test_player_out_of_world_boundaries(self, player: Player):
+        player.position = ((-WORLD_SIZE-100) , 25 , (WORLD_SIZE+120))
+        player.check_player_within_world_boundaries()
+        assert player.position == (-WORLD_SIZE , 25 , WORLD_SIZE)
+
+        player.position = ((WORLD_SIZE+25) , 25 , (-WORLD_SIZE-5))
+        player.check_player_within_world_boundaries()
+        assert player.position == (WORLD_SIZE , 25 , -WORLD_SIZE)
+
+    #issue25
+    def test_player_out_of_world_in_x_coordinate(self, player: Player):
+        player.position = ((WORLD_SIZE+2) , 125 , 15)
+        player.check_player_within_world_boundaries()
+        assert player.position == (WORLD_SIZE , 125 , 15)
+
+        player.position = ((-WORLD_SIZE-200) , 125 , 15)
+        player.check_player_within_world_boundaries()
+        assert player.position == (-WORLD_SIZE , 125 , 15)
+
+    #issue25
+    def test_player_out_of_world_in_z_coordinate(self, player: Player):
+        player.position = (79 , 125 , (WORLD_SIZE+2))
+        player.check_player_within_world_boundaries()
+        assert player.position == (79 , 125 , WORLD_SIZE)
+
+        player.position = (79 , 125 , (-WORLD_SIZE-120))
+        player.check_player_within_world_boundaries()
+        assert player.position == (79 , 125 , -WORLD_SIZE)
+
+    #issue25
+    def test_player_in_y_coordinate(self, player: Player):
+        player.position = (79 , (WORLD_SIZE+1000) , 0)
+        player.check_player_within_world_boundaries()
+        assert player.position == (79 , (WORLD_SIZE+1000) , 0)


### PR DESCRIPTION
Resolved [Issue#25](https://github.com/WSUCEG-7140/Tempus_Fugit_Minecraft/issues/25)

- Implemented a new feature in `player.py`: Introduced an invisible barrier at the end of the game world (the walls).
  - `check_player_within_world_boundaries()` function retrieves the player's `x` and `z` coordinates by calling `keep_player_within_coordinates()`.
  - If the user attempts to move beyond the walls by jumping or walking, the invisible barrier prevents them.
  - The limitation applies only to the `x` (left-right) and `z` (front-back) axes, while there are no restrictions on climbing in the `y` axis (height).
- `check_player_within_world_boundaries()` is invoked from `update()` in `model.py`.
- `update()` is called whenever a game action occurs, meaning it is repeatedly called.
 
**Tests:**
- Added test functions to cover the possible user position scenarios.

**Embedded Design Documentation:**
- Included comments and issue number ([Issue#25](https://github.com/WSUCEG-7140/Tempus_Fugit_Minecraft/issues/25)) for each newly implemented function.